### PR TITLE
Don't handle the directory name (`images/`) as an image

### DIFF
--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -290,7 +290,9 @@ extra_1,  data, 0x06,            ,   20K,
 
         let image_names = zip
             .file_names()
-            .filter(|file_name| file_name.starts_with(Self::IMAGES_PREFIX))
+            .filter(|file_name| {
+                file_name.starts_with(Self::IMAGES_PREFIX) && !file_name.ends_with("/")
+            })
             .map(|file_name| file_name.to_string())
             .collect::<Vec<_>>();
 
@@ -327,7 +329,9 @@ extra_1,  data, 0x06,            ,   20K,
 
         let efuse_names = zip
             .file_names()
-            .filter(|file_name| file_name.starts_with(Self::EFUSES_PREFIX))
+            .filter(|file_name| {
+                file_name.starts_with(Self::EFUSES_PREFIX) && !file_name.ends_with("/")
+            })
             .map(|file_name| file_name.to_string())
             .collect::<Vec<_>>();
 


### PR DESCRIPTION
Hi @ivmarkov 

I have discovered this work on the Matrix chat and wanted to give it a try.
But I have failed to make it work with the error:

```
[ERROR] Preparing a bundle failed: Supplied ELF image is not valid
```

Either with ELF or binary files.

By adding some debug logs, I have discovered that the `image_names` variable contains the value `images/` (the directory name) so I added a filter to remove it.