### PR TITLE
monitor: use espflash configuration

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -226,7 +226,9 @@ fn run() -> anyhow::Result<()> {
 }
 
 fn run_monitor(monitor_args: MonitorArgs) -> anyhow::Result<()> {
-    match espflash::cli::serial_monitor(monitor_args, &espflash::cli::config::Config::default()) {
+    let config =
+        espflash::cli::config::Config::load().unwrap_or(espflash::cli::config::Config::default());
+    match espflash::cli::serial_monitor(monitor_args, &config) {
         Ok(_) => {}
         Err(err) => {
             error!("Running serial monitor returned an error: {err}");


### PR DESCRIPTION
When using the `monitor` subcommand, two questions are asked by `espflash`:

```
✔ Use serial port '/dev/ttyACM0' - USB JTAG/serial debug unit? · yes
✔ Remember this serial port for future use? · yes

thread 'main' panicked at /home/rre/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/espflash-3.3.0/src/cli/config.rs:159:48:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

If `yes` is answered to the question: "Remember this serial port for future use?" the program panic because the `save_path` variable of the espflash Config is not initialized to a valid directory to store a persistent configuration.

Using the load() function allows to skip the questions on next use.